### PR TITLE
Normalize supplier IDs for case-insensitive mapping

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -226,19 +226,28 @@ if isinstance(preview_df, pd.DataFrame) and not preview_df.empty:
     if st.button("Run mapping", type="primary", key="btn_run_mapping"):
         try:
             df_sup = preview_df.rename(columns={supplier_col: "supplier_id"}).copy()
-            df_sup["supplier_id"] = df_sup["supplier_id"].astype(str).str.strip()
+            df_sup["supplier_id"] = (
+                df_sup["supplier_id"].astype(str).str.strip().str.upper()
+            )
             vparam = (vendor or "").strip()
 
-            df_map = _read_sql("""
+            df_map = _read_sql(
+                """
                 SELECT vendor_id, supplier_id, tow_code
                 FROM crosswalk
                 WHERE vendor_id = :v OR vendor_id = ''
-            """, {"v": vparam})
+            """,
+                {"v": vparam},
+            )
+            df_map["supplier_id"] = df_map["supplier_id"].astype(str).str.strip().str.upper()
 
-            lookup = {(r["vendor_id"], r["supplier_id"]): r["tow_code"] for _, r in df_map.iterrows()}
+            lookup = {
+                (r["vendor_id"], r["supplier_id"]): r["tow_code"]
+                for _, r in df_map.iterrows()
+            }
 
             def resolve_tow(supp_code: str) -> Optional[str]:
-                s = str(supp_code)
+                s = str(supp_code).strip().upper()
                 return lookup.get((vparam, s)) or lookup.get(("", s)) or None
 
             df_out = df_sup.copy()


### PR DESCRIPTION
## Summary
- normalize uploaded and crosswalk supplier IDs to uppercase
- perform lookups using uppercased codes to allow case-insensitive mapping

## Testing
- `python -m py_compile streamlit_app.py`
- `pytest`
- `python - <<'PY'
import pandas as pd
lookup = {('', 'SUP1'): 'TOW1', ('', 'SUP2'): 'TOW2'}

def resolve_tow(code):
    s = str(code).strip().upper()
    return lookup.get(('', s))

for code in ['sup1', 'SUP1', 'SuP1', 'sup2', 'SUP2', 'Sup2']:
    print(code, '->', resolve_tow(code))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c43f86d780832f89cddcc13d076236