### PR TITLE
Limit cache clearing to vendor list

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -129,7 +129,7 @@ with cc1:
     vendor_filter = st.text_input("Filter vendors (substring / prefix)", value="", key="vendor_filter")
 with cc2:
     if st.button("Refresh list", key="btn_refresh_vendors"):
-        st.cache_data.clear()
+        _fetch_vendors.clear()
 
 vendors = _fetch_vendors(vendor_filter)
 prev_vendor = st.session_state.get("vendor_select", "")


### PR DESCRIPTION
## Summary
- Avoid clearing all cached data in Streamlit when refreshing vendor list
- Only invalidate `_fetch_vendors` cache so crosswalk counts and other caches remain intact

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c43f7f1aac832f810e783561d9a8e5