### PR TITLE
Reset lock when clearing mapping results

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -209,10 +209,10 @@ with c1:
         for k in ["matched", "unmatched", "matched_cols", "unmatched_cols", "mapped_ready", "map_locked"]:
             st.session_state.pop(k, None)
 with c2:
-    st.session_state["map_locked"] = st.checkbox(
+    st.checkbox(
         "Lock mapping result (prevent reruns from clearing)",
         value=st.session_state.get("map_locked", True),
-        key="chk_lock",
+        key="map_locked",
     )
 
 if isinstance(preview_df, pd.DataFrame) and not preview_df.empty:


### PR DESCRIPTION
## Summary
- Use the `map_locked` key for the mapping lock checkbox so clearing results resets the checkbox

## Testing
- `python -m pytest`
- `python - <<'PY'
import streamlit as st
st.session_state['map_locked'] = False
for k in ["matched", "unmatched", "matched_cols", "unmatched_cols", "mapped_ready", "map_locked"]:
    st.session_state.pop(k, None)
print('map_locked' in st.session_state, st.session_state.get('map_locked', True))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c43f7ab6d0832f86d4a9d35329f99b