### PR TITLE
Clean up final exception block in streamlit_app.py

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -563,3 +563,4 @@ try:
                 st.success("Prefilled — skrolaj gore do 'Add a single mapping'.")
 except Exception as e:
     st.error(f"Search failed: {e}")
+


### PR DESCRIPTION
## Summary
- ensure final exception block ends cleanly with newline

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c43f78909c832f83dce2230f021f4f